### PR TITLE
Update the getDownloadURL function

### DIFF
--- a/src/app/file-upload/file-upload.component.ts
+++ b/src/app/file-upload/file-upload.component.ts
@@ -56,6 +56,8 @@ export class FileUploadComponent {
     // Progress monitoring
     this.percentage = this.task.percentageChanges();
     this.snapshot   = this.task.snapshotChanges().pipe(
+      // The file's download URL
+      finalize(() => this.downloadURL = fileRef.getDownloadURL()),
       tap(snap => {
         console.log(snap)
         if (snap.bytesTransferred === snap.totalBytes) {
@@ -64,10 +66,6 @@ export class FileUploadComponent {
         }
       })
     )
-
-
-    // The file's download URL
-    this.downloadURL = this.task.downloadURL(); 
   }
 
 


### PR DESCRIPTION
getDownloadURL() doesn´t rely on the task anymore and we have to get the URL from the storage ref.

https://github.com/angular/angularfire2/blob/master/docs/storage/storage.md